### PR TITLE
Add secondary button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pkg/*
 *.pyo
 .venv
 coverage
+.idea

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -164,6 +164,7 @@ module Govspeak
       (?:\r|\n|$) # non-capturing match to make sure end of line and linebreak
     }x) do |attributes, text, href|
       button_classes = "govuk-button"
+      button_classes << " govuk-button--secondary" if attributes =~ /secondary/
       /cross-domain-tracking:(?<cross_domain_tracking>.[^\s*]+)/ =~ attributes
       data_attribute = ""
       data_attribute << " data-start='true'" if attributes =~ /start/

--- a/lib/govspeak/post_processor.rb
+++ b/lib/govspeak/post_processor.rb
@@ -104,8 +104,8 @@ module Govspeak
 
     extension("use gem component for buttons") do |document|
       document.css(".govuk-button").map do |el|
-        button_html = GovukPublishingComponents.render(
-          "govuk_publishing_components/components/button",
+        secondary = el.classes.include? "govuk-button--secondary"
+        options = {
           text: el.content,
           href: el["href"],
           start: el["data-start"],
@@ -114,8 +114,14 @@ module Govspeak
             "tracking-code": el["data-tracking-code"],
             "tracking-name": el["data-tracking-name"],
           },
+        }
+        options[:secondary] = secondary
+        button_html = GovukPublishingComponents.render(
+          "govuk_publishing_components/components/button",
+          options,
         ).squish.gsub("> <", "><").gsub!(/\s+/, " ")
 
+        button_html[" gem-c-button--secondary"] = " gem-c-button--secondary govuk-button--secondary" if secondary
         el.swap(button_html)
       end
     end

--- a/test/govspeak_button_test.rb
+++ b/test/govspeak_button_test.rb
@@ -11,6 +11,11 @@ class GovspeakTest < Minitest::Test
     assert_text_output "Start now"
   end
 
+  test_given_govspeak "{button secondary}[Start now](https://www.registertovote.service.gov.uk/register-to-vote/start){/button}" do
+    assert_html_output '<p><a class="gem-c-button govuk-button gem-c-button--secondary govuk-button--secondary" role="button" href="https://www.registertovote.service.gov.uk/register-to-vote/start">Start now</a></p>'
+    assert_text_output "Start now"
+  end
+
   # The same as above but with line breaks
   test_given_govspeak "{button start cross-domain-tracking:UA-23066786-5}\n\n\n[Start now](https://www.registertovote.service.gov.uk/register-to-vote/start)\n\n\n{/button}" do
     assert_html_output '<p><a class="gem-c-button govuk-button govuk-button--start" role="button" data-module="cross-domain-tracking" data-tracking-code="UA-23066786-5" data-tracking-name="govspeakButtonTracker" href="https://www.registertovote.service.gov.uk/register-to-vote/start"> Start now <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewbox="0 0 33 40" role="presentation" focusable="false"><path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path></svg></a></p>'

--- a/test/html_sanitizer_test.rb
+++ b/test/html_sanitizer_test.rb
@@ -35,6 +35,14 @@ class HtmlSanitizerTest < Minitest::Test
     )
   end
 
+  test "allow govspeak secondary button markup" do
+    html = "<a href='#' class=\"govuk-button govuk-button--secondary\"></a>"
+    assert_equal(
+      "<a href=\"#\" class=\"govuk-button govuk-button--secondary\"></a>",
+      Govspeak::HtmlSanitizer.new(html).sanitize,
+    )
+  end
+
   test "allow data attributes on links" do
     html = "<a href='/' data-module='track-click' data-ecommerce-path='/' data-track-category='linkClicked'>Test Link</a>"
 

--- a/test/html_validator_test.rb
+++ b/test/html_validator_test.rb
@@ -99,6 +99,7 @@ class HtmlValidatorTest < Minitest::Test
   test "allow govspeak button" do
     assert Govspeak::HtmlValidator.new("{button}[Start now](https://gov.uk){/button}").valid?
     assert Govspeak::HtmlValidator.new("{button start}[Start now](https://gov.uk){/button}").valid?
+    assert Govspeak::HtmlValidator.new("{button secondary}[Start now](https://gov.uk){/button}").valid?
     assert Govspeak::HtmlValidator.new("{button start cross-domain-tracking:UA-XXXXXX-Y}[Start now](https://gov.uk){/button}").valid?
   end
 


### PR DESCRIPTION
Turns out components repo (https://github.com/alphagov/govuk_publishing_components) does not add `govuk-button--secondary` class, even when the button is in fact secondary.

```
def css_classes
        css_classes = %w[gem-c-button govuk-button]
        css_classes << "govuk-button--start" if start
        css_classes << "gem-c-button--secondary" if secondary
        css_classes << "gem-c-button--secondary-quiet" if secondary_quiet
        css_classes << "govuk-button--warning" if destructive
        css_classes << "gem-c-button--bottom-margin" if margin_bottom && !info_text
        css_classes << "gem-c-button--inline" if inline_layout
        css_classes << classes if classes
        css_classes.join(" ")
      end
```
I guess we could decide to style `gem-c-button--secondary` the same way as we style `govuk-button--secondary` - or we could make a PR to the components repo to include it. Maybe. Happy for someone to try it out next week. In the meantime, this slightly hacky solution should do. 