### PR TITLE
Youtube embeddings

### DIFF
--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -374,10 +374,10 @@ module Govspeak
       %(<govspeak-embed-attachment-link id="#{attachment_id}"></govspeak-embed-attachment-link>)
     end
 
-    extension("Accordion", /\$Accordion\s*$(.*?)\$EndAccordion/m) do |body|
+    extension("Accordion", /\$Accordion\s*$(.*?)\s*\$EndAccordion/m) do |body|
       sections = ""
       index = 1
-      body.scan(/\$Heading\s*([\s\S]*?)\s*\$EndHeading\s*\$Summary\s*([\s\S]*?)\s*\$EndSummary\s*\$Content\s*([\s\S]*?)\s*\$EndContent/) do |heading, summary, content|
+      body.scan(/\$Heading\s*(.*?)\s*\$EndHeading\s*\$Summary\s*(.*?)\s*\$EndSummary\s*\$Content\s*(.*?)\s*\$EndContent/m) do |heading, summary, content|
         if summary.present?
           summary = %(
       <div>#{summary}</div>)
@@ -398,6 +398,12 @@ module Govspeak
         index += 1
       end
       %(<div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">#{sections}</div>)
+    end
+
+    extension("YoutubeVideo", /\$YoutubeVideo\((.*?)\)\$EndYoutubeVideo/m) do |youtube_link|
+      youtube_id = youtube_link.scan(/^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/)[0][1]
+      embed_url = %(https://www.youtube.com/embed/#{youtube_id}?enablejsapi=1&amp;origin=https%3A%2F%2Fwww.early-career-framework.education.gov.uk)
+      %(<iframe class="govspeak-embed-video" title="B1" width="500" height="281" src="#{embed_url}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>)
     end
 
   private

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -374,7 +374,7 @@ module Govspeak
       %(<govspeak-embed-attachment-link id="#{attachment_id}"></govspeak-embed-attachment-link>)
     end
 
-    extension("Accordion", /#{NEW_PARAGRAPH_LOOKBEHIND}\$Accordion\s*$(.*?)\$EndAccordion/m) do |body|
+    extension("Accordion", /\$Accordion\s*$(.*?)\$EndAccordion/m) do |body|
       sections = ""
       index = 1
       body.scan(/\$Heading\s*([\s\S]*?)\s*\$EndHeading\s*\$Summary\s*([\s\S]*?)\s*\$EndSummary\s*\$Content\s*([\s\S]*?)\s*\$EndContent/) do |heading, summary, content|

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -883,4 +883,12 @@ List item 1
 </div>))
     end
   end
+
+  test "Youtube Embedding" do
+    govspeak = "$YoutubeVideo(https://www.youtube.com/watch?v=EpjSlCJtPLo&list=PL4IuMlmijgAfTwwEiZmMp28Eaf66S3a1R&index=2&t=0s)$EndYoutubeVideo"
+    expected_html = %(<iframe title="B1" width="500" height="281" src="https://www.youtube.com/embed/EpjSlCJtPLo?enablejsapi=1&amp;origin=https%3A%2F%2Fwww.early-career-framework.education.gov.uk" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>)
+    given_govspeak(govspeak) do
+      assert_html_output(expected_html)
+    end
+  end
 end


### PR DESCRIPTION
By default sanitize gem gets rid of iframes. I copy-pasted the example they give on [their github](https://github.com/rgrove/sanitize) fro handling youtube videos, and changed it a tiny bit here and there.