### PR TITLE
Fix accessibility problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,7 +714,7 @@ creates an accordion
 
 ### Youtube Video
 
-    $YoutubeVideo(https://www.youtube.com/watch?v=EpjSlCJtPLo&list=PL4IuMlmijgAfTwwEiZmMp28Eaf66S3a1R&index=2&t=0s)$EndYoutubeVideo
+    $YoutubeVideo[Video title](https://www.youtube.com/watch?v=EpjSlCJtPLo&list=PL4IuMlmijgAfTwwEiZmMp28Eaf66S3a1R&index=2&t=0s)$EndYoutubeVideo
     
 creates an iframe with embedded youtube video
 

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -67,6 +67,7 @@ module Govspeak
     def to_html
       # Restart counting on every request
       @accordion_index = 1
+      @accordion_heading_index = 1
 
       @to_html ||= begin
                      html = if @options[:sanitize]
@@ -191,8 +192,8 @@ module Govspeak
     end
 
     extension("stat-headline", %r${stat-headline}(.*?){/stat-headline}$m) do |body|
-      %(\n\n<aside class="stat-headline">
-#{Govspeak::Document.new(body.strip).to_html}</aside>\n)
+      %(\n\n<div class="stat-headline">
+#{Govspeak::Document.new(body.strip).to_html}</div>\n)
     end
 
     # FIXME: these surrounded_by arguments look dodgy
@@ -380,17 +381,18 @@ module Govspeak
         lines << %(<div class="govuk-accordion__section ">)
         lines << %(<div class="govuk-accordion__section-header">)
         lines << %(<h2 class="govuk-accordion__section-heading">)
-        lines << %(<span class="govuk-accordion__section-button" id="accordion-default-heading-#{@accordion_index}">#{heading}</span>)
+        lines << %(<span class="govuk-accordion__section-button" id="accordion-#{@accordion_index}-heading-#{@accordion_heading_index}">#{heading}</span>)
         lines << %(</h2>)
         lines << summary
         lines << %(</div>)
-        lines << %(<div id="accordion-default-content-#{@accordion_index}" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-#{@accordion_index}">)
+        lines << %(<div id="accordion-#{@accordion_index}-content-#{@accordion_heading_index}" class="govuk-accordion__section-content" aria-labelledby="accordion-#{@accordion_index}-heading-#{@accordion_heading_index}">)
         lines << %(<div class='govuk-body'>#{content}</div>)
         lines << %(</div>)
         lines << %(</div>)
-        @accordion_index += 1
+        @accordion_heading_index += 1
       end
-      %(<div class="govuk-accordion" data-module="govuk-accordion">#{lines.join}</div>)
+      @accordion_index += 1
+      %(<div class="govuk-accordion" data-module="govuk-accordion" id="accordion-#{@accordion_index - 1}">#{lines.join}</div>)
     end
 
     extension("YoutubeVideo", /\$YoutubeVideo(?:\[(.*?)\])?\((.*?)\)\$EndYoutubeVideo/m) do |title, youtube_link|

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -65,6 +65,9 @@ module Govspeak
     end
 
     def to_html
+      # Restart counting on every request
+      @accordion_index = 1
+
       @to_html ||= begin
                      html = if @options[:sanitize]
                               HtmlSanitizer.new(kramdown_doc.to_html).sanitize(allowed_elements: @allowed_elements)
@@ -279,18 +282,6 @@ module Govspeak
     # More specific tags must be defined first. Those defined earlier have a
     # higher precedence for being matched. For example $CTA must be defined
     # before $C otherwise the first ($C)TA fill be matched to a contact tag.
-    wrap_with_div("call-to-action", "$CTA", Govspeak::Document)
-    wrap_with_div("summary", "$!")
-    wrap_with_div("form-download", "$D")
-    wrap_with_div("contact", "$C")
-    wrap_with_div("place", "$P", Govspeak::Document)
-    wrap_with_div("information", "$I", Govspeak::Document)
-    wrap_with_div("additional-information", "$AI")
-    wrap_with_div("example", "$E", Govspeak::Document)
-
-    extension("address", surrounded_by("$A")) do |body|
-      %(\n<div class="address"><div class="adr org fn"><p>\n#{body.sub("\n", '').gsub("\n", '<br />')}\n</p></div></div>\n)
-    end
 
     extension("legislative list", /#{NEW_PARAGRAPH_LOOKBEHIND}\$LegislativeList\s*$(.*?)\$EndLegislativeList/m) do |body|
       Govspeak::KramdownOverrides.with_kramdown_ordered_lists_disabled do
@@ -381,7 +372,6 @@ module Govspeak
     end
 
     extension("Accordion", /\$Accordion\s*$(.*?)\s*\$EndAccordion/m) do |body|
-      index = 1
       lines = []
       body.scan(/\$Heading\s*(.*?)\s*\$EndHeading\s*\$Summary\s*(.*?)\s*\$EndSummary\s*\$Content\s*(.*?)\s*\$EndContent/m) do |heading, summary, content|
         if summary.present?
@@ -390,23 +380,24 @@ module Govspeak
         lines << %(<div class="govuk-accordion__section ">)
         lines << %(<div class="govuk-accordion__section-header">)
         lines << %(<h2 class="govuk-accordion__section-heading">)
-        lines << %(<div class="govuk-accordion__section-button" id="accordion-default-heading-#{index}">#{heading}</div>)
+        lines << %(<span class="govuk-accordion__section-button" id="accordion-default-heading-#{@accordion_index}">#{heading}</span>)
         lines << %(</h2>)
         lines << summary
         lines << %(</div>)
-        lines << %(<div id="accordion-default-content-#{index}" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-#{index}">)
+        lines << %(<div id="accordion-default-content-#{@accordion_index}" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-#{@accordion_index}">)
         lines << %(<div class='govuk-body'>#{content}</div>)
         lines << %(</div>)
         lines << %(</div>)
-        index += 1
+        @accordion_index += 1
       end
-      %(<div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">#{lines.join}</div>)
+      %(<div class="govuk-accordion" data-module="govuk-accordion">#{lines.join}</div>)
     end
 
-    extension("YoutubeVideo", /\$YoutubeVideo\((.*?)\)\$EndYoutubeVideo/m) do |youtube_link|
+    extension("YoutubeVideo", /\$YoutubeVideo(?:\[(.*?)\])?\((.*?)\)\$EndYoutubeVideo/m) do |title, youtube_link|
       youtube_id = youtube_link.scan(/^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/)[0][1]
       embed_url = %(https://www.youtube.com/embed/#{youtube_id}?enablejsapi=1&amp;origin=https%3A%2F%2Fwww.early-career-framework.education.gov.uk)
-      %(<iframe class="govspeak-embed-video" width="500" height="281" src="#{embed_url}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>)
+      optional_title = title ? %(title="#{title}") : ""
+      %(<iframe class="govspeak-embed-video" width="500" height="281" src="#{embed_url}" #{optional_title} frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>)
     end
 
     extension("Figure", /\$Figure\s*$(.*?)\s*\$EndFigure/m) do |figure|
@@ -419,6 +410,20 @@ module Govspeak
       lines << %(<figcaption><p>#{caption}</p></figcaption>)
       lines << %(</figure>)
       lines.join
+    end
+
+    wrap_with_div("call-to-action", "$CTA", Govspeak::Document)
+    wrap_with_div("summary", "$!")
+    wrap_with_div("form-download", "$D")
+    wrap_with_div("contact", "$C")
+    wrap_with_div("place", "$P", Govspeak::Document)
+    wrap_with_div("information", "$I", Govspeak::Document)
+    wrap_with_div("additional-information", "$AI")
+    wrap_with_div("example", "$E", Govspeak::Document)
+
+    # This has to be specified after Figure or $A and $Alt get mixed up
+    extension("address", surrounded_by("$A")) do |body|
+      %(\n<div class="address"><div class="adr org fn"><p>\n#{body.sub("\n", '').gsub("\n", '<br />')}\n</p></div></div>\n)
     end
 
   private

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -374,7 +374,7 @@ module Govspeak
     extension("Accordion", /\$Accordion\s*$(.*?)\s*\$EndAccordion/m) do |body|
       index = 1
       accordion_index = @accordion_index
-      @accordion_index++
+      @accordion_index += 1
       lines = []
       body.scan(/\$Heading\s*(.*?)\s*\$EndHeading\s*\$Summary\s*(.*?)\s*\$EndSummary\s*\$Content\s*(.*?)\s*\$EndContent/m) do |heading, summary, content|
         if summary.present?

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -283,7 +283,6 @@ module Govspeak
     # More specific tags must be defined first. Those defined earlier have a
     # higher precedence for being matched. For example $CTA must be defined
     # before $C otherwise the first ($C)TA fill be matched to a contact tag.
-
     extension("legislative list", /#{NEW_PARAGRAPH_LOOKBEHIND}\$LegislativeList\s*$(.*?)\$EndLegislativeList/m) do |body|
       Govspeak::KramdownOverrides.with_kramdown_ordered_lists_disabled do
         Kramdown::Document.new(body.strip).to_html.tap do |doc|
@@ -373,6 +372,9 @@ module Govspeak
     end
 
     extension("Accordion", /\$Accordion\s*$(.*?)\s*\$EndAccordion/m) do |body|
+      index = 1
+      accordion_index = @accordion_index
+      @accordion_index++
       lines = []
       body.scan(/\$Heading\s*(.*?)\s*\$EndHeading\s*\$Summary\s*(.*?)\s*\$EndSummary\s*\$Content\s*(.*?)\s*\$EndContent/m) do |heading, summary, content|
         if summary.present?
@@ -381,18 +383,17 @@ module Govspeak
         lines << %(<div class="govuk-accordion__section ">)
         lines << %(<div class="govuk-accordion__section-header">)
         lines << %(<h2 class="govuk-accordion__section-heading">)
-        lines << %(<span class="govuk-accordion__section-button" id="accordion-#{@accordion_index}-heading-#{@accordion_heading_index}">#{heading}</span>)
+        lines << %(<span class="govuk-accordion__section-button" id="accordion-#{accordion_index}-heading-#{index}">#{heading}</span>)
         lines << %(</h2>)
         lines << summary
         lines << %(</div>)
-        lines << %(<div id="accordion-#{@accordion_index}-content-#{@accordion_heading_index}" class="govuk-accordion__section-content" aria-labelledby="accordion-#{@accordion_index}-heading-#{@accordion_heading_index}">)
+        lines << %(<div id="accordion-#{accordion_index}-content-#{index}" class="govuk-accordion__section-content" aria-labelledby="accordion-#{accordion_index}-heading-#{index}">)
         lines << %(<div class='govuk-body'>#{content}</div>)
         lines << %(</div>)
         lines << %(</div>)
-        @accordion_heading_index += 1
+        index += 1
       end
-      @accordion_index += 1
-      %(<div class="govuk-accordion" data-module="govuk-accordion" id="accordion-#{@accordion_index - 1}">#{lines.join}</div>)
+      %(<div class="govuk-accordion" data-module="govuk-accordion" id="accordion-#{accordion_index}">#{lines.join}</div>)
     end
 
     extension("YoutubeVideo", /\$YoutubeVideo(?:\[(.*?)\])?\((.*?)\)\$EndYoutubeVideo/m) do |title, youtube_link|

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -67,7 +67,6 @@ module Govspeak
     def to_html
       # Restart counting on every request
       @accordion_index = 1
-      @accordion_heading_index = 1
 
       @to_html ||= begin
                      html = if @options[:sanitize]

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -914,6 +914,73 @@ Or so we thought.)
     assert_equal(compress_html(expected_html_output), compress_html(rendered))
   end
 
+  test "Multiple accordions" do
+    govspeak = %($Accordion
+      $Heading Heading 1 $EndHeading$Summary$EndSummary$ContentList item 1$EndContent
+      $Heading Heading 2 $EndHeading$Summary$EndSummary$ContentList item 2$EndContent
+      $EndAccordion
+$Accordion
+      $Heading Heading 1 $EndHeading$Summary$EndSummary$ContentList item 1$EndContent
+      $Heading Heading 2 $EndHeading$Summary$EndSummary$ContentList item 2$EndContent
+      $EndAccordion)
+
+    rendered = Govspeak::Document.new(govspeak).to_html
+    expected_html_output = %(
+      <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-1">
+        <div class="govuk-accordion__section ">
+          <div class="govuk-accordion__section-header">
+            <h2 class="govuk-accordion__section-heading">
+              <span class="govuk-accordion__section-button" id="accordion-1-heading-1">
+                Heading 1
+              </span>
+            </h2>
+          </div>
+          <div id="accordion-1-content-1" class="govuk-accordion__section-content">
+            <div class="govuk-body">List item 1</div>
+          </div>
+        </div>
+        <div class="govuk-accordion__section ">
+          <div class="govuk-accordion__section-header">
+            <h2 class="govuk-accordion__section-heading">
+              <span class="govuk-accordion__section-button" id="accordion-1-heading-2">
+                Heading 2
+              </span>
+            </h2>
+          </div>
+          <div id="accordion-1-content-2" class="govuk-accordion__section-content">
+            <div class="govuk-body">List item 2</div>
+          </div>
+        </div>
+      </div>
+      <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-2">
+        <div class="govuk-accordion__section ">
+          <div class="govuk-accordion__section-header">
+            <h2 class="govuk-accordion__section-heading">
+              <span class="govuk-accordion__section-button" id="accordion-2-heading-1">
+                Heading 1
+              </span>
+            </h2>
+          </div>
+          <div id="accordion-2-content-1" class="govuk-accordion__section-content">
+            <div class="govuk-body">List item 1</div>
+          </div>
+        </div>
+        <div class="govuk-accordion__section ">
+          <div class="govuk-accordion__section-header">
+            <h2 class="govuk-accordion__section-heading">
+              <span class="govuk-accordion__section-button" id="accordion-2-heading-2">
+                Heading 2
+              </span>
+            </h2>
+          </div>
+          <div id="accordion-2-content-2" class="govuk-accordion__section-content">
+            <div class="govuk-body">List item 2</div>
+          </div>
+        </div>
+      </div>)
+    assert_equal(compress_html(expected_html_output), compress_html(rendered))
+  end
+
   test "Youtube Embedding with title" do
     govspeak = "$YoutubeVideo[Test title](https://www.youtube.com/watch?v=EpjSlCJtPLo&list=PL4IuMlmijgAfTwwEiZmMp28Eaf66S3a1R&index=2&t=0s)$EndYoutubeVideo"
     expected_html = %(<iframe width="500" height="281" src="https://www.youtube.com/embed/EpjSlCJtPLo?enablejsapi=1&amp;origin=https%3A%2F%2Fwww.early-career-framework.education.gov.uk" title="Test title" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>)

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -914,7 +914,15 @@ Or so we thought.)
     assert_equal(compress_html(expected_html_output), compress_html(rendered))
   end
 
-  test "Youtube Embedding" do
+  test "Youtube Embedding with title" do
+    govspeak = "$YoutubeVideo[Test title](https://www.youtube.com/watch?v=EpjSlCJtPLo&list=PL4IuMlmijgAfTwwEiZmMp28Eaf66S3a1R&index=2&t=0s)$EndYoutubeVideo"
+    expected_html = %(<iframe width="500" height="281" src="https://www.youtube.com/embed/EpjSlCJtPLo?enablejsapi=1&amp;origin=https%3A%2F%2Fwww.early-career-framework.education.gov.uk" title="Test title" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>)
+    given_govspeak(govspeak) do
+      assert_html_output(expected_html)
+    end
+  end
+
+  test "Youtube Embedding without title" do
     govspeak = "$YoutubeVideo(https://www.youtube.com/watch?v=EpjSlCJtPLo&list=PL4IuMlmijgAfTwwEiZmMp28Eaf66S3a1R&index=2&t=0s)$EndYoutubeVideo"
     expected_html = %(<iframe width="500" height="281" src="https://www.youtube.com/embed/EpjSlCJtPLo?enablejsapi=1&amp;origin=https%3A%2F%2Fwww.early-career-framework.education.gov.uk" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>)
     given_govspeak(govspeak) do

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -34,7 +34,7 @@ class GovspeakTest < Minitest::Test
 
   test "stat-headline block extension" do
     rendered = Govspeak::Document.new("this \n{stat-headline}*13.8bn* Age of the universe in years{/stat-headline}").to_html
-    assert_equal %(<p>this</p>\n\n<aside class="stat-headline">\n<p><em>13.8bn</em> Age of the universe in years</p>\n</aside>\n), rendered
+    assert_equal %(<p>this</p>\n\n<div class="stat-headline">\n<p><em>13.8bn</em> Age of the universe in years</p>\n</div>\n), rendered
   end
 
   test "extracts headers with text, level and generated id" do
@@ -868,17 +868,17 @@ Or so we thought.)
 
     rendered = Govspeak::Document.new(govspeak).to_html
     expected_html_output = %(
-      <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+      <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-1">
         <div class="govuk-accordion__section ">
           <div class="govuk-accordion__section-header">
             <h2 class="govuk-accordion__section-heading">
-              <div class="govuk-accordion__section-button" id="accordion-default-heading-1">
+              <span class="govuk-accordion__section-button" id="accordion-1-heading-1">
                 Heading 1
-              </div>
+              </span>
             </h2>
             <div>Summary 1</div>
           </div>
-          <div id="accordion-default-content-1" class="govuk-accordion__section-content">
+          <div id="accordion-1-content-1" class="govuk-accordion__section-content">
             <div class="govuk-body">
               <span>
                 List item 1
@@ -889,24 +889,24 @@ Or so we thought.)
         <div class="govuk-accordion__section ">
           <div class="govuk-accordion__section-header">
             <h2 class="govuk-accordion__section-heading">
-              <div class="govuk-accordion__section-button" id="accordion-default-heading-2">
+              <span class="govuk-accordion__section-button" id="accordion-1-heading-2">
                 Heading 2
-              </div>
+              </span>
             </h2>
           </div>
-          <div id="accordion-default-content-2" class="govuk-accordion__section-content">
+          <div id="accordion-1-content-2" class="govuk-accordion__section-content">
             <div class="govuk-body">List item 2</div>
           </div>
         </div>
         <div class="govuk-accordion__section ">
           <div class="govuk-accordion__section-header">
             <h2 class="govuk-accordion__section-heading">
-              <div class="govuk-accordion__section-button" id="accordion-default-heading-3">
+              <span class="govuk-accordion__section-button" id="accordion-1-heading-3">
                 Heading 3
-              </div>
+              </span>
             </h2>
           </div>
-          <div id="accordion-default-content-3" class="govuk-accordion__section-content">
+          <div id="accordion-1-content-3" class="govuk-accordion__section-content">
             <div class="govuk-body">List item 3</div>
           </div>
         </div>


### PR DESCRIPTION
The only change from a user point of view is that Youtube videos should now be given titles. It still works if you don't so is backwards compatible, but won't be accessible.