### PR TITLE
Add details extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,3 +745,29 @@ creates the following html:
     </figcaption>
 </figure>
 ```
+
+### Details 
+
+    $Details
+    $Heading
+    Heading
+    $EndHeading
+    $Content
+    Content
+    $EndContent
+    $EndDetails
+
+creates the following html:
+
+```html
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      Summary
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <p>Content</p>
+  </div>
+</details>
+```

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -414,6 +414,27 @@ module Govspeak
       lines.join
     end
 
+    extension("Details", /\$Details\s*$(.*?)\s*\$EndDetails/m) do |body|
+      lines = []
+
+      body.scan(/\$Heading\s*(.*?)\s*\$EndHeading\s*\$Content\s*(.*?)\s*\$EndContent/m) do |summary, content|
+
+        summary_html = Govspeak::Document.new(summary).to_html.remove!("<p>").remove!("</p>")
+        content_html = Govspeak::Document.new(content.strip).to_html
+
+        lines << %(<details class="govuk-details" data-module="govuk-details">)
+        lines << %(<summary class="govuk-details__summary">)
+        lines << %(<span class="govuk-details__summary-text">#{summary_html}</span>)
+        lines << %(</summary>)
+        lines << %(<div class="govuk-details__text">)
+        lines << content_html
+        lines << %(</div>)
+        lines << %(</details>)
+      end
+
+      lines.join
+    end
+
     wrap_with_div("section", "$Section", Govspeak::Document)
     wrap_with_div("call-to-action", "$CTA", Govspeak::Document)
     wrap_with_div("summary", "$!")

--- a/lib/govspeak/html_sanitizer.rb
+++ b/lib/govspeak/html_sanitizer.rb
@@ -84,13 +84,14 @@ class Govspeak::HtmlSanitizer
   def sanitize_config(allowed_elements: [])
     Sanitize::Config.merge(
       Sanitize::Config::RELAXED,
-      elements: Sanitize::Config::RELAXED[:elements] + %w[govspeak-embed-attachment govspeak-embed-attachment-link svg path].concat(allowed_elements),
+      elements: Sanitize::Config::RELAXED[:elements] + %w[govspeak-embed-attachment govspeak-embed-attachment-link svg path details].concat(allowed_elements),
       attributes: {
         :all => Sanitize::Config::RELAXED[:attributes][:all] + %w[role aria-label],
         "a" => Sanitize::Config::RELAXED[:attributes]["a"] + [:data],
         "svg" => Sanitize::Config::RELAXED[:attributes][:all] + %w[xmlns width height viewbox focusable],
         "path" => Sanitize::Config::RELAXED[:attributes][:all] + %w[fill d],
         "div" => [:data],
+        "details" => Sanitize::Config::RELAXED[:attributes][:all] + %w[data-module],
         "th" => Sanitize::Config::RELAXED[:attributes]["th"] + %w[style],
         "td" => Sanitize::Config::RELAXED[:attributes]["td"] + %w[style],
         "govspeak-embed-attachment" => %w[content-id],

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -1019,4 +1019,35 @@ $Accordion
       </figure>)
     assert_equal(compress_html(expected_html_output), compress_html(rendered))
   end
+
+  test "Details" do
+    govspeak = "$Details
+    $Heading
+    This is a details heading
+    $EndHeading
+    $Content
+- List item 1
+- List item 2
+- List item 3
+    $EndContent
+    $EndDetails"
+
+    rendered = Govspeak::Document.new(govspeak, allowed_elements: %w[details]).to_html
+    expected_html_output = %(
+      <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            This is a details heading
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <ul>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
+          </ul>
+        </div>
+      </details>)
+    assert_equal(compress_html(expected_html_output), compress_html(rendered))
+  end
 end


### PR DESCRIPTION
#### Details
This change will allow us to add use a details component in the ECF materials rendered in markdown.

I think it still needs some work to clean up but as it is, the code works. 

the `<details>` tag was initially being removed by the html_sanitizer until I worked out that there's a list of allowed elements. (or at least that's what i think is going on).

See [details component](https://design-system.service.gov.uk/components/details/) on gov uk design for additional info.

#### Changes
- Details extension added
- Test to check what's being rendered is what we need in html. 
- Updated `html_sanitizer` to allow details element and data-module in that element.

#### How to check it works with ECF.

1. Get [ECF repo](https://github.com/DFE-Digital/ecf-engage-and-learn) 
2. Change the govspeak gem ref to the most recent commit in this PR
3. Run ECF E&L locally
4. Login as admin
5. Edit a material and preview the below. You should see the same as what's pictured below. 

````
$Details
$Heading
Lorem ipsum dolor sit amet
$EndHeading
$List
- Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
- Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
- Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
$EndList
$EndDetails
````
<img width="958" alt="Screenshot 2021-07-02 at 08 20 22" src="https://user-images.githubusercontent.com/69353998/124236823-c8cf8380-db0e-11eb-9572-590fac35acaf.png">