### PR TITLE
adds index value to section id

### DIFF
--- a/lib/govspeak/post_processor.rb
+++ b/lib/govspeak/post_processor.rb
@@ -143,6 +143,14 @@ module Govspeak
       end
     end
 
+    extension("increase section index") do |document|
+      document.css("div.section").map.with_index do |el, index|
+        el.children
+          .select {|child| child[:id] }
+          .each   {|child| child[:id] = "section-#{index + 1}-#{child[:id]}"}
+      end
+    end
+
     attr_reader :input, :govspeak_document
 
     def initialize(html, govspeak_document)

--- a/test/govspeak_section_test.rb
+++ b/test/govspeak_section_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+require "govspeak_test_helper"
+
+require "ostruct"
+
+class GovspeakSectionTest < Minitest::Test
+    include GovspeakTestHelper
+
+  def compress_html(html)
+    html.gsub(/[\n\r]+[\s]*/, "")
+  end
+
+  test "section elements with ID won't be duplicated" do
+    govspeak = " 
+$Section
+##### Example header
+section content example
+$Section
+
+$Section
+##### Example header
+section content example again
+$Section
+" 
+            
+    rendered = Govspeak::Document.new(govspeak).to_html
+
+    expected_html_output = %(<div class="section">
+    <h5 id="section-1-example-header">Example header</h5>
+    <p>section content example</p>
+    </div>
+
+    <div class="section">
+    <h5 id="section-2-example-header">Example header</h5>
+    <p>section content example again</p>
+    </div>
+    )
+
+    assert_equal(compress_html(expected_html_output), compress_html(rendered))
+  end
+end


### PR DESCRIPTION
IDs in sections were causing an issue with accessibility as duplicate id tags were being created. This change adds a number to each section solving this issue with the accessibility checker. 

Test:
- Get the ecf-engage-and-learn-repo
- Point the ecf-govspeak gem at the most recent commit in this PR
- Go to a lesson with sections `/edt/year-1/autumn-1/topic-2/part-6`
- Inspect the elements and you should see that they're numbered, example below

<img width="430" alt="Screenshot 2021-07-08 at 11 18 53" src="https://user-images.githubusercontent.com/69353998/124905927-74307a80-dfde-11eb-8b1a-d1b1fccdab95.png">
