### PR TITLE
Fix accessibility id issue for information and call-to-actions

### DIFF
--- a/lib/govspeak/post_processor.rb
+++ b/lib/govspeak/post_processor.rb
@@ -14,6 +14,16 @@ module Govspeak
       @extensions << [title, block]
     end
 
+    def self.add_index_to_element_id(element)
+      extension("add index id to element") do |document|
+        document.css("div.#{element}").map.with_index do |el, index|
+          el.children
+            .select {|child| child[:id] }
+            .each   {|child| child[:id] = "#{element}-header-#{index + 1}-#{child[:id]}"}
+        end
+      end
+    end
+
     extension("add class to last p of blockquote") do |document|
       document.css("blockquote p:last-child").map do |el|
         el[:class] = "last-child"
@@ -143,29 +153,10 @@ module Govspeak
       end
     end
 
-    extension("increase section index") do |document|
-      document.css("div.section").map.with_index do |el, index|
-        el.children
-          .select {|child| child[:id] }
-          .each   {|child| child[:id] = "section-#{index + 1}-#{child[:id]}"}
-      end
-    end
+    add_index_to_element_id("section")
+    add_index_to_element_id("call-to-action")
+    add_index_to_element_id("information")
 
-    extension("increase header index in a call to action block") do |document|
-      document.css("div.call-to-action").map.with_index do |el, index|
-        el.children
-          .select {|child| child[:id] }
-          .each   {|child| child[:id] = "call-to-action-header-#{index + 1}-#{child[:id]}"}
-      end
-    end
-
-    extension("increase header index in an information block") do |document|
-      document.css("div.information").map.with_index do |el, index|
-        el.children
-          .select {|child| child[:id] }
-          .each   {|child| child[:id] = "information-header-#{index + 1}-#{child[:id]}"}
-      end
-    end
     attr_reader :input, :govspeak_document
 
     def initialize(html, govspeak_document)

--- a/lib/govspeak/post_processor.rb
+++ b/lib/govspeak/post_processor.rb
@@ -151,6 +151,21 @@ module Govspeak
       end
     end
 
+    extension("increase header index in a call to action block") do |document|
+      document.css("div.call-to-action").map.with_index do |el, index|
+        el.children
+          .select {|child| child[:id] }
+          .each   {|child| child[:id] = "call-to-action-header-#{index + 1}-#{child[:id]}"}
+      end
+    end
+
+    extension("increase header index in an information block") do |document|
+      document.css("div.information").map.with_index do |el, index|
+        el.children
+          .select {|child| child[:id] }
+          .each   {|child| child[:id] = "information-header-#{index + 1}-#{child[:id]}"}
+      end
+    end
     attr_reader :input, :govspeak_document
 
     def initialize(html, govspeak_document)

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -408,6 +408,17 @@ Teston
   end
 
   test_given_govspeak "
+    $I
+    ### a header
+    $I"  do
+
+  assert_html_output  %(
+    <div class="information">
+    <h3 id="information-header-1-a-header">a header</h3>
+    </div>)
+  end
+
+  test_given_govspeak "
     $D
     can you tell me how to get to...
     $D" do
@@ -461,6 +472,36 @@ Teston
       <div class="contact">
       <p>Here is some text</p>
       </div>)
+  end
+
+  test_given_govspeak "
+    $CTA
+    ###In your notepad
+    $CTA
+    " do
+  assert_html_output %(
+    <div class="call-to-action">
+    <h3 id="call-to-action-header-1-in-your-notepad">In your notepad</h3>
+    </div>)
+  end
+
+  test_given_govspeak "
+    $CTA
+    ###In your notepad
+    $CTA
+
+    $CTA
+    ###In your notepad
+    $CTA
+    " do
+    assert_html_output %(
+    <div class="call-to-action">
+    <h3 id="call-to-action-header-1-in-your-notepad">In your notepad</h3>
+    </div>
+
+    <div class="call-to-action">
+    <h3 id="call-to-action-header-2-in-your-notepad">In your notepad</h3>
+    </div>)
   end
 
   test_given_govspeak "


### PR DESCRIPTION
Accessibility check for lessons were failing because of repeated IDs on information and call-to-actions.

This change aims to solve this issue with adding an index to each id. 

You can check it by running the ECF E&L rails app locally and changing the ECF-Govspeak commit to the most recent commit in this PR. 

I had a problem initially in that it wasn't working, however, this was because the lesson content in the rails app was written in html. In order for this to work, the content needs to be in Markdown first. 

**Test urls**

`/edt/year-1/summer-1/topic-5/part-3`
`/edt/year-2/autumn-1/topic-3/part-3`
 `/teach-first/year-1/spring-2/topic-4/part-2`