### PR TITLE
Update youtube iframe to fit with E&L rails app content

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,7 +719,7 @@ creates an accordion
 creates an iframe with embedded youtube video
 
 ```html
-<iframe width="500" height="281" src="https://www.youtube.com/embed/EpjSlCJtPLo?enablejsapi=1&amp;origin=https%3A%2F%2Fwww.early-career-framework.education.gov.uk" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
+<iframe width="625" height="345" src="https://www.youtube.com/embed/EpjSlCJtPLo?enablejsapi=1&amp;origin=https%3A%2F%2Fwww.early-career-framework.education.gov.uk" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>
 ```
 
 ### Figures with images from markdown

--- a/lib/govspeak.rb
+++ b/lib/govspeak.rb
@@ -403,7 +403,7 @@ module Govspeak
       youtube_id = youtube_link.scan(/^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/)[0][1]
       embed_url = %(https://www.youtube.com/embed/#{youtube_id}?enablejsapi=1&amp;origin=https%3A%2F%2Fwww.early-career-framework.education.gov.uk)
       optional_title = title ? %(title="#{title}") : ""
-      %(<iframe class="govspeak-embed-video" width="500" height="281" src="#{embed_url}" #{optional_title} frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>)
+      %(<iframe class="govspeak-embed-video" width="625" height="345" src="#{embed_url}" #{optional_title} frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>)
     end
 
     extension("Figure", /\$Figure\s*$(.*?)\s*\$EndFigure/m) do |figure|

--- a/test/govspeak_test.rb
+++ b/test/govspeak_test.rb
@@ -1100,7 +1100,7 @@ $Accordion
 
   test "Youtube Embedding with title" do
     govspeak = "$YoutubeVideo[Test title](https://www.youtube.com/watch?v=EpjSlCJtPLo&list=PL4IuMlmijgAfTwwEiZmMp28Eaf66S3a1R&index=2&t=0s)$EndYoutubeVideo"
-    expected_html = %(<iframe width="500" height="281" src="https://www.youtube.com/embed/EpjSlCJtPLo?enablejsapi=1&amp;origin=https%3A%2F%2Fwww.early-career-framework.education.gov.uk" title="Test title" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>)
+    expected_html = %(<iframe width="625" height="345" src="https://www.youtube.com/embed/EpjSlCJtPLo?enablejsapi=1&amp;origin=https%3A%2F%2Fwww.early-career-framework.education.gov.uk" title="Test title" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>)
     given_govspeak(govspeak) do
       assert_html_output(expected_html)
     end
@@ -1108,7 +1108,7 @@ $Accordion
 
   test "Youtube Embedding without title" do
     govspeak = "$YoutubeVideo(https://www.youtube.com/watch?v=EpjSlCJtPLo&list=PL4IuMlmijgAfTwwEiZmMp28Eaf66S3a1R&index=2&t=0s)$EndYoutubeVideo"
-    expected_html = %(<iframe width="500" height="281" src="https://www.youtube.com/embed/EpjSlCJtPLo?enablejsapi=1&amp;origin=https%3A%2F%2Fwww.early-career-framework.education.gov.uk" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>)
+    expected_html = %(<iframe width="625" height="345" src="https://www.youtube.com/embed/EpjSlCJtPLo?enablejsapi=1&amp;origin=https%3A%2F%2Fwww.early-career-framework.education.gov.uk" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>)
     given_govspeak(govspeak) do
       assert_html_output(expected_html)
     end


### PR DESCRIPTION
Dom asked if we could make the youtube video frame size the same width as the content. 

This attempts to do that. Nothing particularly technical about how i chose the size. Start at 640 x 360 and worked backwards until it matched the content. 

Test 
Change the ECF E&L gemfile commit to the most recent in this PR.
Go to lesson with a video. 

It should look as below.

<img width="681" alt="Screenshot 2021-07-28 at 13 21 32" src="https://user-images.githubusercontent.com/69353998/127321362-e977db88-a639-49a1-a49b-c3abffec612f.png">
